### PR TITLE
Fix Warning: Empty `slug` generated for ''

### DIFF
--- a/_posts/2020-05-20-Cloud-based-workers-for-openQA.md
+++ b/_posts/2020-05-20-Cloud-based-workers-for-openQA.md
@@ -7,7 +7,6 @@ title: Cloud based workers for openQA
 image: /assets/images/2020-05-20/RPi3_and_SabreLite.jpg
 categories:
 - infrastructure
-- 
 tags:
 - infrastructure
 - openQA


### PR DESCRIPTION
We have a blog post with an empty category, which is being used in the following code of the [openSUSE Jekyll theme](https://github.com/openSUSE/jekyll-theme/blob/master/_includes/header.html#L40):
```
{ category_name | slugify }
```

This causes the following warning:
```
Warning: Empty `slug` generated for ''.
```

Even more important, it renders an empty category in the menu:
![Screenshot_20201105_164704](https://user-images.githubusercontent.com/16052290/98263017-92913280-1f86-11eb-9481-44af1d0fd787.png)


Remove the empty category to fix this issue. We may want to change how this is implemented in the theme or ensure that categories can't be empty (maybe with GitHub actions) to avoid problems with empty categories.

Closes https://github.com/openSUSE/news-o-o/issues/46