### PR TITLE
Updates to Full Disk Encryption with TPM2 blog post based on latest run.

### DIFF
--- a/_posts/2024/2024-09-20-quickstart-fde-yast2.md
+++ b/_posts/2024/2024-09-20-quickstart-fde-yast2.md
@@ -60,13 +60,19 @@ Boot new system
 * Login
 * Enroll system:
   * With TPM2 chip: `sdbootutil enroll --method tpm2`
-  * With FIDO2 key: `sdbootutil enroll --method fido2`
+  * With FIDO2 key: `sdbootutil enroll --method fido2` 
+* Make a note of the recovery pin. If you receive a `keyctl_set_timeout permission denied` error with the above commands, 
+  try executing them within a root user shell (e.g. `sudo bash`) versus using `sudo sdbootutil enroll ..`.
 * Optional, but recommended:
   * Upgrade your LUKS key derivation function (do that for every encrypted device listed in `/etc/crypttab`):
   ```
           # cryptsetup luksConvertKey /dev/vdaX --pbkdf argon2id
           # cryptsetup luksConvertKey /dev/vdaY --pbkdf argon2id
   ```
+  If `/etc/crypttab` indicates devices with a `UUID=..` instead of `/dev/..` then use the syntax:
+  ```
+          # cryptsetup luksConvertKey UUID=.. --pbkdf argon2id
+  ``` 
 
 ## Adjusting kernel boot parameters
 


### PR DESCRIPTION
Hi,

I followed this from scratch today and just opening a pull request based on my experience.

Note that if I did `sudo sdbootutil enroll --method tpm2`, I got a permission denied error after a while, but switching to a root shell via `sudo bash` and re-running the command seemed to work which was strange. :thinking: 

Lastly, `crypttab` was using UUIDs for the drives vs `/dev/..`.

Kind regards,
Lucas