### PR TITLE
fix: 🐞 update .h-96px class fonr color fix for dark and light themes

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -154,10 +154,22 @@ pre {
   text-decoration: none;
 }
 
+
+@media (prefers-color-scheme: dark) {
 .h-96px {
   height: 72px;
   overflow-y: hidden;
-  color:white
+  color: white;
+}
+}
+
+
+@media (prefers-color-scheme: light) {
+.h-96px {
+  height: 72px;
+  overflow-y: hidden;
+  color:black
+}
 }
 
 .breadcrumb{


### PR DESCRIPTION
Fix #383 for light theme mentation by @cboltz. Thank you for pointing out. 

Dark theme 

<img width="765" height="367" alt="image" src="https://github.com/user-attachments/assets/8a3c4f6f-6718-45f0-adc9-f5b82de01a30" />


Light theme

<img width="653" height="334" alt="image" src="https://github.com/user-attachments/assets/a171958d-553b-480a-897f-0bb34b35ed3d" />
