### PR TITLE
Feat: add category index.html page

### DIFF
--- a/category/index.html
+++ b/category/index.html
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Categories
+permalink: /category/
+---
+
+<div class="category-list">
+  <ul>
+    {% for cat in site.categories %}
+      {% assign cat_name = cat | first %}
+      <li>
+        <a href="{{ site.url }}/category/{{ cat_name | slugify }}/">
+          {{ cat_name }}
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+</div>


### PR DESCRIPTION
Issue:
https://github.com/openSUSE/news-o-o/issues/198

Description:
Create a /category indext.html page that contains all the categories and an href that will go to the individual categories pages 

